### PR TITLE
Improved standardization of phone numbers

### DIFF
--- a/table_connector.py
+++ b/table_connector.py
@@ -50,7 +50,7 @@ def __standardize_phone_numbers(row):
     if '@' not in phone_or_email:
         # Change unbreakable space characters into regular spaces.
         phone_or_email = phone_or_email.replace(u'\xa0', u' ')
-        phone_or_email = re.sub('[()\- ]+', '', phone_or_email)
+        phone_or_email = re.sub(r'[()\- ]+', '', phone_or_email)
     return re.sub(r'(\+?1)(\d{10})', r'\2', phone_or_email)
 
 

--- a/table_connector.py
+++ b/table_connector.py
@@ -44,9 +44,13 @@ def __get_latest_dir_in_dir(directory):
     return newest_path
 
 
-# Removes a leading one if it exists.
-def __strip_initial_1_in_phone(row):
+# Removes leading ones from phone numbers as well as any spaces or punctuation.
+def __standardize_phone_numbers(row):
     phone_or_email = row.phone_or_email
+    if '@' not in phone_or_email:
+        # Change unbreakable space characters into regular spaces.
+        phone_or_email = phone_or_email.replace(u'\xa0', u' ')
+        phone_or_email = re.sub('[()\- ]+', '', phone_or_email)
     return re.sub(r'(\+?1)(\d{10})', r'\2', phone_or_email)
 
 
@@ -70,7 +74,7 @@ def __get_message_id_joined_to_phone_or_email():
     # Clean it up a bit.
     message_id_joined_to_phone_or_email['country'] = message_id_joined_to_phone_or_email['country'].str.lower()
     message_id_joined_to_phone_or_email['phone_or_email'] = message_id_joined_to_phone_or_email.apply(
-        __strip_initial_1_in_phone, axis=1)
+        __standardize_phone_numbers, axis=1)
     return message_id_joined_to_phone_or_email
 
 
@@ -159,8 +163,7 @@ def get_address_book():
 
     # Clean it up a bit.
     address_book = address_book[(address_book['property'] == 4) | (address_book['property'] == 3)]  # Of type phone or email
-    address_book['phone_or_email'] = address_book['phone_or_email'].str.replace(r'[()\- ]', '')
-    address_book['phone_or_email'] = address_book.apply(__strip_initial_1_in_phone, axis=1)
+    address_book['phone_or_email'] = address_book.apply(__standardize_phone_numbers, axis=1)
 
     # Convert a few columns to dates.
     address_book['birthday'] = pd.to_datetime(address_book['birthday'], errors='coerce')


### PR DESCRIPTION
When looking at the list of people who I texted the most, I noticed something seemed off. I realized that a lot of my text messages weren't getting accredited to the right person (and were instead being marked as having an "Unknown" sender/ recipient) because punctuation wasn't being stripped correctly.

I looked into it a little bit and the issue was that some of the phone numbers in my iMessage backup include non-breakable spaces (unicode character 160) instead of the regular space (32). These spaces therefore weren't being subbed out by the regex correctly. In this pull request, I fixed this issue and rolled up all of the phone number standardization into a single function.
