### PR TITLE
Python 3 compatibility

### DIFF
--- a/sms_analysis.ipynb
+++ b/sms_analysis.ipynb
@@ -706,8 +706,8 @@
    "source": [
     "widgets.interact(\n",
     "    get_word_summary_for_diffs,\n",
-    "    contact=widgets.Text(value='Mom', description='1st Contact:', placeholder='Enter 1st name'),\n",
-    "    other_contact=widgets.Text(value='Dad', description='2nd Contact:', placeholder='Enter 2nd name'),\n",
+    "    contact=widgets.Text(description='1st Contact:', placeholder='Enter 1st name'),\n",
+    "    other_contact=widgets.Text(description='2nd Contact:', placeholder='Enter 2nd name'),\n",
     "    top_n=widgets.IntSlider(description='Max words to show:', min=10, max=100, step=1, value=5)\n",
     ")"
    ]

--- a/sms_analysis.ipynb
+++ b/sms_analysis.ipynb
@@ -3,8 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "toc": "true"
    },
    "source": [
@@ -14,10 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "See the README for an explanation of how this code runs and functions.\n",
     "\n",
@@ -26,10 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Imports"
    ]
@@ -38,17 +30,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function\n",
+    "from __future__ import division\n",
+    "\n",
     "import copy\n",
     "import json\n",
     "import re\n",
     "import string\n",
-    "from __future__ import print_function\n",
     "\n",
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
@@ -68,10 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Load the data from disk and set up the dataframes"
    ]
@@ -80,9 +69,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -97,16 +84,14 @@
     "\n",
     "WORDS_PER_PAGE = 450  # Based upon http://wordstopages.com/\n",
     "print('\\nTotal pages if all texts were printed: {0:,d} (Arial size 12, single spaced)\\n'.format(\n",
-    "    int(sum(fully_merged_messages_df.text.apply(lambda x: len(x.split())))/WORDS_PER_PAGE)))"
+    "    int(sum(fully_merged_messages_df.text.apply(lambda x: len(x.split())))//WORDS_PER_PAGE)))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -118,9 +103,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -129,20 +112,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**Use `fully_merged_messages_df` and `address_book_df` for analysis, they contain all messages with columns for the sender and all contacts, respectively**"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Show a heatmap of how many texts you've exchanged"
    ]
@@ -152,8 +129,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -197,9 +172,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "source": [
     "# Table and graph of who you text the most"
@@ -210,8 +183,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": true
    },
    "outputs": [],
@@ -235,8 +206,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -252,20 +221,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Steamgraph"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Dump the necessary data to JS"
    ]
@@ -275,8 +238,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -305,10 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Draw the graph!"
    ]
@@ -318,8 +276,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -345,20 +301,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Wordcloud"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Define the helper method"
    ]
@@ -367,9 +317,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -396,10 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Texts you've sent"
    ]
@@ -409,8 +354,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -427,10 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Texts to/from a specific contact"
    ]
@@ -440,14 +380,18 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "# Helper method so we can wrap it with interact().\n",
+    "def convert_unicode_to_str_if_needed(unicode_or_str):\n",
+    "    if type(unicode_or_str).__name__ == 'unicode':\n",
+    "        return unicode_or_str.encode('utf-8')\n",
+    "    return unicode_or_str\n",
+    "\n",
     "def _word_cloud_specific_contact(max_words, from_me, contact):\n",
+    "    contact = convert_unicode_to_str_if_needed(contact)\n",
     "    if contact not in full_names:\n",
     "        print('{} not found'.format(contact))\n",
     "        return\n",
@@ -467,20 +411,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Diving deeper into the actual text"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Visualize a word tree of texts exchanged with a specific contact"
    ]
@@ -489,9 +427,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -514,10 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Preprocessing and data munging for TFIDF"
    ]
@@ -526,13 +459,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "punctuation = str(copy.copy(string.punctuation))\n",
+    "punctuation = copy.copy(string.punctuation)\n",
     "punctuation += u'“”‘’\\ufffc\\uff0c'  # Include some UTF-8 punctuation that occurred.\n",
     "punct_regex = re.compile(u'[{0}]'.format(punctuation))\n",
     "spaces_regex = re.compile(r'\\s{2,}')\n",
@@ -555,9 +486,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -571,10 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Create TFIDF matrix for all contacts\n",
     "\n",
@@ -586,8 +512,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -609,10 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Helper methods to leverage the TFIDF matrix"
    ]
@@ -622,13 +543,12 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": true
    },
    "outputs": [],
    "source": [
     "def get_word_summary_for_contact(contact, top_n=25):\n",
+    "    contact = convert_unicode_to_str_if_needed(contact)\n",
     "    tfidf_record = _get_tfidf_record_for_contact(contact)\n",
     "    if tfidf_record is None:\n",
     "        print('\"{0}\" was not found.'.format(contact))\n",
@@ -637,6 +557,9 @@
     "    return pd.DataFrame({'Word': word_list.iloc[sorted_indices[:top_n]]}).reset_index(drop=True)\n",
     "\n",
     "def get_word_summary_for_diffs(contact, other_contact, top_n=25):\n",
+    "    contact = convert_unicode_to_str_if_needed(contact)\n",
+    "    other_contact = convert_unicode_to_str_if_needed(other_contact)\n",
+    "    \n",
     "    tfidf_record_contact = _get_tfidf_record_for_contact(contact)\n",
     "    tfidf_record_other_contact = _get_tfidf_record_for_contact(other_contact)\n",
     "    \n",
@@ -658,10 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Words that identify a specific contact"
    ]
@@ -670,9 +590,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -685,10 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Words that identify the difference between two contacts"
    ]
@@ -698,8 +613,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -714,20 +627,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Looking at language progression over the years"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Helper methods for looking at TFIDF by year"
    ]
@@ -736,9 +643,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -809,10 +714,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### My top words over the years\n",
     "\n",
@@ -823,9 +725,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -835,10 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Top words over the years from/to a specific contact\n",
     "\n",
@@ -849,14 +746,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "# Wrapper method so we can use interact().\n",
     "def _top_words_by_year_for_contact(contact, from_me, top_n):\n",
+    "    contact = convert_unicode_to_str_if_needed(contact)\n",
     "    if contact not in full_names:\n",
     "        print('\"{0}\" not found'.format(contact))\n",
     "        return\n",
@@ -873,15 +769,6 @@
     "    top_n=widgets.IntSlider(min=15, max=100, step=1, value=5, description='Max words to show:')\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/sms_analysis.ipynb
+++ b/sms_analysis.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "toc": "true"
    },
    "source": [
@@ -12,7 +14,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "See the README for an explanation of how this code runs and functions.\n",
     "\n",
@@ -21,7 +26,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Imports"
    ]
@@ -30,7 +38,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -38,6 +48,7 @@
     "import json\n",
     "import re\n",
     "import string\n",
+    "from __future__ import print_function\n",
     "\n",
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
@@ -57,7 +68,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Load the data from disk and set up the dataframes"
    ]
@@ -66,7 +80,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -80,15 +96,17 @@
     "fully_merged_messages_df.full_name.replace('nan nan nan', 'Unknown', inplace=True)\n",
     "\n",
     "WORDS_PER_PAGE = 450  # Based upon http://wordstopages.com/\n",
-    "print '\\nTotal pages if all texts were printed: {0:,d} (Arial size 12, single spaced)\\n'.format(\n",
-    "    sum(fully_merged_messages_df.text.apply(lambda x: len(x.split())))/WORDS_PER_PAGE)"
+    "print('\\nTotal pages if all texts were printed: {0:,d} (Arial size 12, single spaced)\\n'.format(\n",
+    "    int(sum(fully_merged_messages_df.text.apply(lambda x: len(x.split())))/WORDS_PER_PAGE)))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -100,7 +118,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -109,14 +129,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "**Use `fully_merged_messages_df` and `address_book_df` for analysis, they contain all messages with columns for the sender and all contacts, respectively**"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Show a heatmap of how many texts you've exchanged"
    ]
@@ -126,6 +152,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -156,7 +184,7 @@
     "    if trim_incomplete:\n",
     "        month_year_messages_pivot = month_year_messages_pivot[month_year_messages_pivot.count(axis=1) == 12]\n",
     "    if month_year_messages_pivot.shape[0] == 0:\n",
-    "        print 'After trimming rows that didn\\'t have 12 months, no rows remained, bailing out.'\n",
+    "        print('After trimming rows that didn\\'t have 12 months, no rows remained, bailing out.')\n",
     "        return\n",
     "\n",
     "    f, ax = plt.subplots(figsize=figsize)\n",
@@ -169,7 +197,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "source": [
     "# Table and graph of who you text the most"
@@ -180,6 +210,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": true
    },
    "outputs": [],
@@ -203,6 +235,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -218,14 +252,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Steamgraph"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Dump the necessary data to JS"
    ]
@@ -235,6 +275,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -263,7 +305,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Draw the graph!"
    ]
@@ -273,6 +318,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -298,14 +345,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Wordcloud"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Define the helper method"
    ]
@@ -314,7 +367,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -331,7 +386,7 @@
     "                          relative_scaling=1,\n",
     "                          max_words=max_words\n",
     "                         ).generate_from_text(words)\n",
-    "    print 'Based on {0:,} texts'.format(len(texts))\n",
+    "    print('Based on {0:,} texts'.format(len(texts)))\n",
     "    \n",
     "    fig, ax = plt.subplots(figsize=(15,10))\n",
     "    ax.imshow(wordcloud)\n",
@@ -341,7 +396,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Texts you've sent"
    ]
@@ -351,6 +409,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -367,7 +427,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Texts to/from a specific contact"
    ]
@@ -377,15 +440,16 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "# Helper method so we can wrap it with interact().\n",
     "def _word_cloud_specific_contact(max_words, from_me, contact):\n",
-    "    contact = contact.encode('utf-8')\n",
     "    if contact not in full_names:\n",
-    "        print contact + ' not found'\n",
+    "        print('{} not found'.format(contact))\n",
     "        return\n",
     "    sliced_df = fully_merged_messages_df[(fully_merged_messages_df.full_name == contact) &\n",
     "                                         (fully_merged_messages_df.is_from_me == from_me)].text\n",
@@ -403,14 +467,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Diving deeper into the actual text"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Visualize a word tree of texts exchanged with a specific contact"
    ]
@@ -419,14 +489,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "# Note this requires an internet connection to load Google's JS library.\n",
     "def get_json_for_word_tree(contact):\n",
     "    df = fully_merged_messages_df[(fully_merged_messages_df.full_name == contact)]\n",
-    "    print 'Exchanged {0:,} texts with {1}'.format(df.shape[0], contact)\n",
+    "    print('Exchanged {0:,} texts with {1}'.format(df.shape[0], contact))\n",
     "    \n",
     "    array_for_json = [[text[1]] for text in df.text.iteritems()]\n",
     "    array_for_json.insert(0, [['Phrases']])\n",
@@ -442,7 +514,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Preprocessing and data munging for TFIDF"
    ]
@@ -451,11 +526,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
-    "punctuation = unicode(copy.copy(string.punctuation))\n",
+    "punctuation = str(copy.copy(string.punctuation))\n",
     "punctuation += u'“”‘’\\ufffc\\uff0c'  # Include some UTF-8 punctuation that occurred.\n",
     "punct_regex = re.compile(u'[{0}]'.format(punctuation))\n",
     "spaces_regex = re.compile(r'\\s{2,}')\n",
@@ -478,7 +555,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -492,7 +571,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Create TFIDF matrix for all contacts\n",
     "\n",
@@ -504,6 +586,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -519,13 +603,16 @@
     "tfidf_transformed_dataset = vectorizer.fit_transform(grouped_by_name.text)\n",
     "word_list = pd.Series(vectorizer.get_feature_names())\n",
     "\n",
-    "print 'TFIDF sparse matrix is {0}MB'.format(tfidf_transformed_dataset.data.nbytes / 1024 / 1024)\n",
-    "print 'TFIDF matrix has shape: {0}'.format(tfidf_transformed_dataset.shape)"
+    "print('TFIDF sparse matrix is {0}MB'.format(tfidf_transformed_dataset.data.nbytes / 1024 / 1024))\n",
+    "print('TFIDF matrix has shape: {0}'.format(tfidf_transformed_dataset.shape))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Helper methods to leverage the TFIDF matrix"
    ]
@@ -535,30 +622,28 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": true
    },
    "outputs": [],
    "source": [
     "def get_word_summary_for_contact(contact, top_n=25):\n",
-    "    contact = contact.encode('utf-8')\n",
     "    tfidf_record = _get_tfidf_record_for_contact(contact)\n",
     "    if tfidf_record is None:\n",
-    "        print '\"{0}\" was not found.'.format(contact)\n",
+    "        print('\"{0}\" was not found.'.format(contact))\n",
     "        return\n",
     "    sorted_indices = tfidf_record.argsort()[::-1]\n",
     "    return pd.DataFrame({'Word': word_list.iloc[sorted_indices[:top_n]]}).reset_index(drop=True)\n",
     "\n",
     "def get_word_summary_for_diffs(contact, other_contact, top_n=25):\n",
-    "    contact = contact.encode('utf-8')\n",
-    "    other_contact = other_contact.encode('utf-8')\n",
-    "    \n",
     "    tfidf_record_contact = _get_tfidf_record_for_contact(contact)\n",
     "    tfidf_record_other_contact = _get_tfidf_record_for_contact(other_contact)\n",
     "    \n",
     "    if tfidf_record_contact is None or tfidf_record_other_contact is None:\n",
     "        # Print out the first contact not found.\n",
     "        contact_not_found = contact if tfidf_record_contact is None else other_contact\n",
-    "        print '\"{0}\" was not found.'.format(contact_not_found)\n",
+    "        print('\"{0}\" was not found.'.format(contact_not_found))\n",
     "        return\n",
     "    sorted_indices = (tfidf_record_contact - tfidf_record_other_contact).argsort()[::-1]\n",
     "    return pd.DataFrame({'Word': word_list.iloc[sorted_indices[:top_n]]}).reset_index(drop=True)\n",
@@ -573,7 +658,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Words that identify a specific contact"
    ]
@@ -582,7 +670,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -595,7 +685,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Words that identify the difference between two contacts"
    ]
@@ -605,28 +698,36 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "widgets.interact(\n",
     "    get_word_summary_for_diffs,\n",
-    "    contact=widgets.Text(description='1st Contact:', placeholder='Enter 1st name'),\n",
-    "    other_contact=widgets.Text(description='2nd Contact:', placeholder='Enter 2nd name'),\n",
+    "    contact=widgets.Text(value='Mom', description='1st Contact:', placeholder='Enter 1st name'),\n",
+    "    other_contact=widgets.Text(value='Dad', description='2nd Contact:', placeholder='Enter 2nd name'),\n",
     "    top_n=widgets.IntSlider(description='Max words to show:', min=10, max=100, step=1, value=5)\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Looking at language progression over the years"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Helper methods for looking at TFIDF by year"
    ]
@@ -635,7 +736,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -689,24 +792,27 @@
     "\n",
     "    # Drops years with less than min_texts_required texts since they won't be very meaningful.\n",
     "    years_to_drop = grouped_by_year[grouped_by_year['count'] < min_texts_required].index\n",
-    "    print 'Dropping year(s): {0}, each had fewer than {1} texts.'.format(\n",
-    "        ', '.join(str(year) for year in years_to_drop), min_texts_required)\n",
+    "    print('Dropping year(s): {0}, each had fewer than {1} texts.'.format(\n",
+    "        ', '.join(str(year) for year in years_to_drop), min_texts_required))\n",
     "    grouped_by_year = grouped_by_year[grouped_by_year['count'] >= min_texts_required]\n",
     "    grouped_by_year.index.name = 'year'\n",
     "\n",
     "    if grouped_by_year.shape[0] == 0:\n",
-    "        print 'Bailing out, no years found with at least {0} texts.'.format(min_texts_required)\n",
+    "        print('Bailing out, no years found with at least {0} texts.'.format(min_texts_required))\n",
     "        return None\n",
     "\n",
     "    grouped_by_year_tfidf = vectorizer.transform(grouped_by_year['text'])\n",
-    "    print 'Found {0} years with more than {1} texts each.'.format(grouped_by_year_tfidf.shape[0],\n",
-    "                                                                  min_texts_required)\n",
+    "    print('Found {0} years with more than {1} texts each.'.format(grouped_by_year_tfidf.shape[0],\n",
+    "                                                                  min_texts_required))\n",
     "    return grouped_by_year_tfidf, grouped_by_year.index"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### My top words over the years\n",
     "\n",
@@ -717,7 +823,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -727,7 +835,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Top words over the years from/to a specific contact\n",
     "\n",
@@ -738,15 +849,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "# Wrapper method so we can use interact().\n",
     "def _top_words_by_year_for_contact(contact, from_me, top_n):\n",
-    "    contact = contact.encode('utf-8')\n",
     "    if contact not in full_names:\n",
-    "        print '\"{0}\" not found'.format(contact)\n",
+    "        print('\"{0}\" not found'.format(contact))\n",
     "        return\n",
     "    # Slice to texts from/to the contact.\n",
     "    df = fully_merged_messages_df[(fully_merged_messages_df.is_from_me == from_me) &\n",
@@ -761,6 +873,15 @@
     "    top_n=widgets.IntSlider(min=15, max=100, step=1, value=5, description='Max words to show:')\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Python 3 appears to be a lot fast, so I fixed all compatibility issues.
* Changed all print functions to be python 3 compatible
* Removed utf-8 encoding - it appears to work without

I'm sorry the diff is so big. Somehow jupyter added some meta data that I do not know how to remove.